### PR TITLE
Support more keywords and LF-only line endings

### DIFF
--- a/src/indent.js
+++ b/src/indent.js
@@ -9,20 +9,24 @@ var Indent = function (config) {
     this.languageIndex = '0';
     var words = {
         scenario: ['Scenario'],
+        background: ['Background'],
         given: ['Given'],
         when: ['When'],
         then: ['Then'],
         and: ['And'],
         but: ['But'],
+        examples: ['Examples'],
     };
 
     var activeWords = {
         scenario: words.scenario[this.languageIndex],
+        background: words.background[this.languageIndex],
         given: words.given[this.languageIndex],
         when: words.when[this.languageIndex],
         then: words.then[this.languageIndex],
         and: words.and[this.languageIndex],
         but: words.but[this.languageIndex],
+        examples: words.examples[this.languageIndex],
     }
 
     this.init = function (originalText) {
@@ -78,6 +82,13 @@ var Indent = function (config) {
                 this.lines[index] = this.leftPad(line, activeWords.and);
             } else if (this.isValidStep(line, activeWords.but)) {
                 this.lines[index] = this.leftPad(line, activeWords.but);
+   
+            } else if (this.isValidStep(line, activeWords.scenario)) {
+                this.lines[index] = this.leftPad(line, activeWords.scenario);
+            } else if (this.isValidStep(line, activeWords.background)) {
+                this.lines[index] = this.leftPad(line, activeWords.background);
+            } else if (this.isValidStep(line, activeWords.examples)) {
+                this.lines[index] = this.leftPad(line, activeWords.examples);
             }
         }, this);
     }
@@ -143,8 +154,28 @@ var Indent = function (config) {
         if (this.stepIndent > stepName.length) {
             var from = str.indexOf(stepName);
             var rem = str.substr(from, str.length - from);
-            var step = Array(this.stepIndent - stepName.length + 1).join(" ") + rem;
+            var step;
+
+            if(stepName === activeWords.scenario) {
+                step = Array(this.stepIndent - stepName.length).join(" ") + rem
+                
+            } else if (stepName === activeWords.background) {
+                step = this.leftPadAmount(rem, this.stepIndent - stepName.length + 2);
+                
+            } else if (stepName === activeWords.examples) {
+                step = this.leftPadAmount(rem, this.stepIndent - stepName.length + 4);
+                
+            } else {
+                step = this.leftPadAmount(rem, this.stepIndent - stepName.length + 1);
+            }
             return step;
+        }
+        return str;
+    }
+
+    this.leftPadAmount = function (str, distance) {
+        if(distance > 0) {
+            str = Array(distance).join(" ") + str;
         }
         return str;
     }

--- a/src/indent.js
+++ b/src/indent.js
@@ -127,7 +127,7 @@ var Indent = function (config) {
         }
 
         for (i = 0; i < indexes.length; i++) {
-                rows[indexes[i]].value = columns[i].join('|');
+            rows[indexes[i]].value = this.leftPadAmount(columns[i].join('|'), this.stepIndent);
         }
 
         return rows;

--- a/src/indent.js
+++ b/src/indent.js
@@ -7,6 +7,7 @@ var Indent = function (config) {
     this.originalText = "";
     this.lines = [];
     this.languageIndex = '0';
+    this.lineEndings = '\r\n';
     var words = {
         scenario: ['Scenario'],
         background: ['Background'],
@@ -32,7 +33,12 @@ var Indent = function (config) {
     this.init = function (originalText) {
         var formatedText = '';
         this.originalText = originalText;
-        this.lines = this.originalText.split('\r\n');
+        // Figure out the line ending type
+        if(this.originalText.match(/\r\n/) === null) {
+            this.lineEndings = '\n';
+        }
+        
+        this.lines = this.originalText.split(this.lineEndings);
         if (this.lines[this.lines.length - 1].indexOf('|') !== -1)
             this.lines.push(" ");
     }
@@ -50,7 +56,7 @@ var Indent = function (config) {
             }, this);
         }, this);
 
-        formatedText = this.lines.join('\r\n');
+        formatedText = this.lines.join(this.lineEndings);
         return formatedText;
     }
 


### PR DESCRIPTION
While working with your plugin I've found that indentation of Scenarios, Backgrounds, Examples and example tables could improve the workflow at my company greatly. Also, we've encountered the same problem as in #5, but did not find that solution satisfactory as it replaces `\n` (LF) line endings with `\r\n` line endings (CRLF).

**Changes**
The plugin will now:
* Indent Scenarios, Backgrounds and Examples using an abstracted method for left padding
* Indent Example tables using the same method
* Check whether the line endings are `\r\n`, and if not use `\n` instead
* Join the lines back together using the line endings previously detected

**Known issues**
* Lines starting with a comment(`#`) and including the `|` character crash the plugin.
* This version assumes 4 spaces per tab are used for indentation of the example tables
* Indenting of Scenarios, Backgrounds and Examples only works with a step-indent setting of 11 and up